### PR TITLE
Fixed PropTypes for React 16

### DIFF
--- a/app/ReactMLFragment.jsx
+++ b/app/ReactMLFragment.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLFragment extends React.Component {
   static displayName = 'ReactMLFragment';
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
   };
 
   render() {

--- a/app/components/ReactMLBold.jsx
+++ b/app/components/ReactMLBold.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLBold extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <span className='reactml-b' style={{ fontWeight: 'bold' }}>

--- a/app/components/ReactMLCode.jsx
+++ b/app/components/ReactMLCode.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLCode extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <pre className='reactml-code'>

--- a/app/components/ReactMLFragment.jsx
+++ b/app/components/ReactMLFragment.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLFragment extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
   };
 
   render() {

--- a/app/components/ReactMLImage.jsx
+++ b/app/components/ReactMLImage.jsx
@@ -1,9 +1,10 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLImage extends React.Component {
   static propTypes = {
-    label: React.PropTypes.string,
-    url: React.PropTypes.string,
+    label: PropTypes.string,
+    url: PropTypes.string,
   };
 
   render() {

--- a/app/components/ReactMLItalic.jsx
+++ b/app/components/ReactMLItalic.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLItalic extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <span className='reactml-i' style={{ fontStyle: 'italic' }}>

--- a/app/components/ReactMLItem.jsx
+++ b/app/components/ReactMLItem.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLItem extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <li className='reactml-item'>

--- a/app/components/ReactMLLink.jsx
+++ b/app/components/ReactMLLink.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLLink extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
     url: React.PropTypes.string,
   };
 

--- a/app/components/ReactMLList.jsx
+++ b/app/components/ReactMLList.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLList extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <ul className='reactml-list'>

--- a/app/components/ReactMLParagraph.jsx
+++ b/app/components/ReactMLParagraph.jsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLParagraph extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
+    children: PropTypes.node,
   };
 
   render() {

--- a/app/components/ReactMLQuote.jsx
+++ b/app/components/ReactMLQuote.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLQuote extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <blockquote className='reactml-quote'>

--- a/app/components/ReactMLStrikethrough.jsx
+++ b/app/components/ReactMLStrikethrough.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLStrikethrough extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <span className='reactml-s' style={{ textDecoration: 'line-through' }}>

--- a/app/components/ReactMLUnderline.jsx
+++ b/app/components/ReactMLUnderline.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 class ReactMLUnderline extends React.Component {
   static propTypes = {
-    children: React.PropTypes.node,
-  }
+    children: PropTypes.node,
+  };
+
   render() {
     const { children } = this.props;
     return <span className='reactml-u' style={{ textDecoration: 'underline' }}>

--- a/package.json
+++ b/package.json
@@ -95,7 +95,8 @@
     "babel-runtime": "^6.3.19",
     "bluebird": "^3.0.6",
     "cheerio": "^0.19.0",
-    "lodash": "^3.10.1"
+    "lodash": "^3.10.1",
+    "prop-types": "^15.6.0"
   },
   "peerDependencies": {
     "react": "^0.14.3"


### PR DESCRIPTION
A quick and easy change that makes the package work with newer releases of React where PropTypes is stored in a separate package. 👍 

Edit: For anyone Googling this issue I've put this change up on NPM as react-ml-2, npm install react-ml-2 to get it.